### PR TITLE
エラー位置をエディタ上に表示する機能と、エラーメッセージを色付きで表示する機能への対応

### DIFF
--- a/app/action/show.inc.php
+++ b/app/action/show.inc.php
@@ -96,6 +96,7 @@ function n3s_show_get($agent)
             $js_a[] = '<script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.4.12/ace.js" integrity="sha512-GZ1RIgZaSc8rnco/8CXfRdCpDxRCphenIiZ2ztLy3XQfCbQUSCuk8IudvNHxkRA3oUg6q0qejgN/qqyG1duv5Q==" crossorigin="anonymous"></script>';
             $js_a[] = '<script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.4.12/ext-language_tools.min.js" integrity="sha512-8qx1DL/2Wsrrij2TWX5UzvEaYOFVndR7BogdpOyF4ocMfnfkw28qt8ULkXD9Tef0bLvh3TpnSAljDC7uyniEuQ==" crossorigin="anonymous"></script>';
             $js_a[] = '<script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.4.12/ext-options.min.js" integrity="sha512-oHR+WVzBiVZ6njlMVlDDLUIOLRDfUUfRQ55PfkZvgjwuvGqL4ohCTxaahJIxTmtya4jgyk0zmOxDMuLzbfqQDA==" crossorigin="anonymous"></script>';
+            $js_a[] = '<script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.4.12/ext-code_lens.min.js" integrity="sha512-gsDyyKTnOmSWRDzUbpYcPjzVsEyFGSWeWefzVKvbMULPR2ElIlKKsOtU3ycfybN9kncZXKLFSsUiG3cgJUbc/g==" crossorigin="anonymous"></script>';
         }
 
         // add other plugins

--- a/app/template/nako3storage_show.js
+++ b/app/template/nako3storage_show.js
@@ -63,7 +63,7 @@ function runButtonOnClick() { // 実行ボタンを押した時
   
   // デフォルトコードを追加する
   var div_name = '#nako3_div'
-  const head =
+  let preCode =
     "F=JS実行(\"(typeof(sys)=='undefined')?'null':typeof sys.__v0['DOM親要素設定']\");" +
     "もし、F=「function」ならば;" + 
     "  『「" + div_name + "」へDOM親要素設定;" +
@@ -74,15 +74,15 @@ function runButtonOnClick() { // 実行ボタンを押した時
     "カメ全消去;" +
     "カメ画像URL=「" + baseurl + "/demo/turtle.png」;"
   if (verInt >= 3108) {
-    code = head + "‰\n" + code
+    preCode += "‰\n"
   } else {
-    code = head + ";" + code
+    preCode += ";\n"
   }
   // プログラムを実行
   try {
     runbox.style.display = 'block'
     nako3_clear();
-    navigator.nako3.run(code);
+    navigator.nako3.run(preCode + code);
     runCount++ // 正しく実行した回数をチェック
   } catch (e) {
     showError(e.message)

--- a/app/template/show.html
+++ b/app/template/show.html
@@ -16,9 +16,14 @@
     <button id="runButton" class="pure-button pure-button-primary">▶　実 行</button>
     <button id="clearButton" class="pure-button">クリア</button>
     <div id="runbox">
-      <div id="nako3_error" style="display:none"></div>
+      <!-- 3.1.19以上 -->
+      <div id="nako3_output"></div>
+
+      <!-- 3.1.18以下 -->
+      <div id="nako3_error" style="display:none"></div> 
       <textarea class="nako3row nako3info" readonly
             id="nako3_info" rows="5" style="display:none"></textarea>
+  
       <canvas id='nako3_canvas' width='{{$canvas_w}}' height='{{$canvas_h}}'></canvas>
       <div id='nako3_div' class='nako3_div'></div>
       <div>
@@ -124,8 +129,10 @@
 
 <!-- script for nako3storage-->
 <script type="text/javascript">
+  //nako3storage_show.js から参照する変数
   var setValue = function() { alert("現在ライブラリを読み込み中です。しばらくお待ちください。") }
-  var getValue = function() { alert("現在ライブラリを読み込み中です。しばらくお待ちください。") }
+  var getValue = function() { alert("現在ライブラリを読み込み中です。しばらくお待ちください。"); return "" }
+  var editorObjects = null
 
   function setupEditor() {
       if (navigator.nako3 === undefined) {
@@ -144,12 +151,12 @@
         div.dataset.nako3Resizable = "true"
         div.textContent = nako3code.value
 
-        const editor = navigator.nako3.setupEditor("nako3code");
-        editor.editor.on("change", function(e) {
-          localStorage["n3s_save_body"] = editor.editor.getValue()
+        editorObjects = navigator.nako3.setupEditor("nako3code");
+        editorObjects.editor.on("change", function(e) {
+          localStorage["n3s_save_body"] = editorObjects.editor.getValue()
         })
-        setValue = function(text) { editor.editor.setValue(text) }
-        getValue = function() { return editor.editor.getValue() }
+        setValue = function(text) { editorObjects.editor.setValue(text) }
+        getValue = function() { return editorObjects.editor.getValue() }
       } else {
         // 3.1.17未満のときはtextareaで表示する。
         nako3code.addEventListener("change", function(e) {

--- a/app/template/widget.html
+++ b/app/template/widget.html
@@ -83,6 +83,10 @@
       <button id="clearButton" class="pure-button">クリア</button>
     </div>
     <div id="runbox">
+      <!-- 3.1.19以上 -->
+      <div id="nako3_output"></div>
+
+      <!-- 3.1.18以下 -->
       <div class="nako3row nako3info" id="nako3_info"></div>
       <canvas id='nako3_canvas' width='{{$canvas_w}}' height='{{$canvas_h}}'></canvas>
       <div id='nako3_div' class='nako3_div'></div>
@@ -101,8 +105,11 @@
       // nako3 program info
       const app_id = {{ $app_id }};
       const nako_version = "{{ $version }}" + ".0.0.0"
+
+      //nako3storage_show.js から参照する変数
       const setValue = function(text) { document.getElementById('nako3code').value = text }
       const getValue = function(text) { return document.getElementById('nako3code').value }
+      var editorObjects = null
     </script>
     <script defer type="text/javascript"
       src="{{e:echo n3s_getURL('nako3storage_show.js', 'file', ['m'=>$mtime_nako3storage_show]);}}"></script>

--- a/skin/def/n3s.css
+++ b/skin/def/n3s.css
@@ -138,6 +138,17 @@ h2 {
   padding: 1em;
 }
 
+#nako3_output {
+  border: 1px solid silver;
+  max-height: 200px;
+  resize: vertical;
+  box-sizing: content-box;
+  background-color: #f0f0f04b;
+  margin: 4px;
+  padding: 4px 4px 16px 16px;
+  overflow-y: auto;
+}
+
 .nako3info {
   border: 1px solid silver;
   background-color: #f0f0ff;


### PR DESCRIPTION
なでしこ言語側の実装で構文エラーが起きたかどうかを取得する処理を用意していなかったため、構文エラーが起きてもプログラムを投稿できてしまいます。それと、preCode内の「ナデシコ続」によって最初（警告がある場合はその次の行）に1行空白行が出力されてしまう問題もあります。
![Screenshot from 2021-03-06 15-25-08](https://user-images.githubusercontent.com/54441600/110197705-be6ae900-7e90-11eb-9188-7e36411aef15.png)
