### PR TITLE
IE以外でもeditor.runが使われない問題の修正

### DIFF
--- a/app/template/nako3storage_show.js
+++ b/app/template/nako3storage_show.js
@@ -114,7 +114,7 @@ function runButtonOnClick() { // 実行ボタンを押した時
 
     // ページ内にエディタが存在してかつバージョンが3.1.19以上ならeditor.runを使える
     // 但しmsieであればeditor.runを使わない (#61)
-    if (editorObjects && verInt >= 3119 && (!isIE)) {
+    if (editorObjects && verInt >= 3119 && !isIE()) {
       document.getElementById('nako3_output').style.display = 'block'
       const logger = editorObjects.run({ 
         'preCode': preCode, 


### PR DESCRIPTION
関数 `isIE` を `!isIE()` ではなく `!isIE` の形で使っているせいで、常にfalseになります。
