### PR TITLE
feat: 実行回数・アクセス数の統計機能を追加 (#217)

### DIFF
--- a/app/action/rec_widget.inc.php
+++ b/app/action/rec_widget.inc.php
@@ -31,14 +31,17 @@ function n3s_api_rec_widget()
     }
 
     // 作品が存在するか・公開かを確認（余分な情報は漏らさない）
-    $app = db_get1('SELECT user_id, is_private FROM apps WHERE app_id=?', [$app_id]);
+    $app = db_get1('SELECT user_id, is_private, editkey FROM apps WHERE app_id=?', [$app_id]);
     if (!$app) {
         // 存在しなくても 200 を返す（存在チェックを悪用させない）
         n3s_api_output(true, []);
         return;
     }
-    // 非公開の場合はカウントしない
-    if (intval($app['is_private']) === 1) {
+    // 閲覧権限がない場合はカウントしない
+    // is_private=1（非公開）および is_private=2（限定公開）を editkey なしで直接呼んで
+    // 統計を水増しできる問題を修正 (P1 security fix)
+    $editkey = isset($_GET['editkey']) ? $_GET['editkey'] : '';
+    if (!n3s_private_access_allowed($app, $editkey)) {
         n3s_api_output(true, []);
         return;
     }

--- a/app/action/rec_widget.inc.php
+++ b/app/action/rec_widget.inc.php
@@ -5,7 +5,7 @@
  * widget.html (sandbox 内) から run=0 で「実行」ボタンが押されたとき、
  * JavaScript 側が fetch でこのエンドポイントを呼び、実行回数を記録する。
  *
- * GET / POST: index.php?action=rec_widget&page=<app_id>
+ * GET: api.php?action=rec_widget&page=<app_id>
  *
  * セキュリティ:
  *  - 副作用は access_stats テーブルへの書き込みのみ。

--- a/app/action/rec_widget.inc.php
+++ b/app/action/rec_widget.inc.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * ウィジェット実行カウント用 API (Issue #217)
+ *
+ * widget.html (sandbox 内) から run=0 で「実行」ボタンが押されたとき、
+ * JavaScript 側が fetch でこのエンドポイントを呼び、実行回数を記録する。
+ *
+ * GET / POST: index.php?action=rec_widget&page=<app_id>
+ *
+ * セキュリティ:
+ *  - 副作用は access_stats テーブルへの書き込みのみ。
+ *  - ログイン投稿の作品オーナー本人の実行は除外する（widget_frame.inc.php と同ルール）。
+ *  - app_id が存在しない / 非公開の場合は単純に 200 OK で空レスポンスを返す
+ *    （存在チェックのエラー詳細をクライアントに漏らさない）。
+ */
+
+// web エンドポイントは無効（API 専用）
+function n3s_web_rec_widget()
+{
+    http_response_code(405);
+    exit;
+}
+
+function n3s_api_rec_widget()
+{
+    // app_id を取得・検証
+    $app_id = isset($_GET['page']) ? intval($_GET['page']) : 0;
+    if ($app_id <= 0) {
+        n3s_api_output(false, ['msg' => 'invalid app_id']);
+        return;
+    }
+
+    // 作品が存在するか・公開かを確認（余分な情報は漏らさない）
+    $app = db_get1('SELECT user_id, is_private FROM apps WHERE app_id=?', [$app_id]);
+    if (!$app) {
+        // 存在しなくても 200 を返す（存在チェックを悪用させない）
+        n3s_api_output(true, []);
+        return;
+    }
+    // 非公開の場合はカウントしない
+    if (intval($app['is_private']) === 1) {
+        n3s_api_output(true, []);
+        return;
+    }
+
+    // オーナー本人の実行は除外（widget_frame.inc.php と同ルール）
+    $owner_id = intval($app['user_id']);
+    if ($owner_id > 0 && n3s_get_user_id() === $owner_id) {
+        n3s_api_output(true, []);
+        return;
+    }
+
+    // 実行回数を記録
+    n3s_record_access('widget', $app_id);
+    n3s_api_output(true, []);
+}

--- a/app/action/show.inc.php
+++ b/app/action/show.inc.php
@@ -12,6 +12,10 @@ function n3s_web_show()
     $sandbox_url = n3s_get_config('sandbox_url', '');
     $a['sandbox_url'] = "{$sandbox_url}index.php?action=widget_frame&page={$page}&mute_title=1&editkey={$editkey}";
     n3s_set_config('page_title', $a['title']);
+    // 閲覧統計を記録 (Issue #217)
+    if (!empty($a['app_id'])) {
+        n3s_record_access('show', $a['app_id']);
+    }
     n3s_template_fw('show.html', $a);
 }
 
@@ -34,6 +38,8 @@ function n3s_api_show()
             'user_id' => $a['user_id'],
             'body' => $a['body'],
         ];
+        // APIアクセス統計を記録 (Issue #217)
+        n3s_record_access('api', $a['app_id']);
     }
     n3s_api_output($a['result'], $result);
 }

--- a/app/action/stats.inc.php
+++ b/app/action/stats.inc.php
@@ -1,0 +1,99 @@
+<?php
+// for clickjacking
+header('X-Frame-Options: SAMEORIGIN');
+
+// no api access
+function n3s_api_stats()
+{
+    n3s_api_output(false, ['msg' => 'should use web access']);
+}
+
+function n3s_web_stats()
+{
+    if (!n3s_is_admin()) {
+        n3s_error('admin only', '管理者専用のページです');
+        return;
+    }
+
+    // 直近30日間の日別統計を取得
+    $days = 30;
+    $since = date('Y-m-d', strtotime("-{$days} days"));
+
+    $daily_show   = n3s_stats_get_daily('show',   $since);
+    $daily_widget = n3s_stats_get_daily('widget', $since);
+    $daily_api    = n3s_stats_get_daily('api',    $since);
+
+    // 合計値
+    $total_show   = array_sum(array_column($daily_show,   'count'));
+    $total_widget = array_sum(array_column($daily_widget, 'count'));
+    $total_api    = array_sum(array_column($daily_api,    'count'));
+
+    // アクセス数上位の作品 (show/widget)
+    $top_show   = n3s_stats_top_apps('show',   $since, 10);
+    $top_widget = n3s_stats_top_apps('widget', $since, 10);
+
+    // 日付リストを作成してチャートデータ用に整形
+    $date_labels   = [];
+    $show_counts   = [];
+    $widget_counts = [];
+    $api_counts    = [];
+    $daily_show_map   = array_column($daily_show,   'count', 'date');
+    $daily_widget_map = array_column($daily_widget, 'count', 'date');
+    $daily_api_map    = array_column($daily_api,    'count', 'date');
+    for ($i = $days - 1; $i >= 0; $i--) {
+        $d = date('Y-m-d', strtotime("-{$i} days"));
+        $date_labels[]   = $d;
+        $show_counts[]   = isset($daily_show_map[$d])   ? intval($daily_show_map[$d])   : 0;
+        $widget_counts[] = isset($daily_widget_map[$d]) ? intval($daily_widget_map[$d]) : 0;
+        $api_counts[]    = isset($daily_api_map[$d])    ? intval($daily_api_map[$d])    : 0;
+    }
+
+    n3s_template_fw('stats.html', [
+        'days'          => $days,
+        'since'         => $since,
+        'total_show'    => $total_show,
+        'total_widget'  => $total_widget,
+        'total_api'     => $total_api,
+        'date_labels'   => json_encode($date_labels,   JSON_UNESCAPED_UNICODE),
+        'show_counts'   => json_encode($show_counts,   JSON_UNESCAPED_UNICODE),
+        'widget_counts' => json_encode($widget_counts, JSON_UNESCAPED_UNICODE),
+        'api_counts'    => json_encode($api_counts,    JSON_UNESCAPED_UNICODE),
+        'top_show'      => $top_show,
+        'top_widget'    => $top_widget,
+    ]);
+}
+
+/**
+ * 日別のアクセス合計 (app_id=0 の行) を取得する
+ */
+function n3s_stats_get_daily($kind, $since)
+{
+    $rows = db_get(
+        'SELECT date, count FROM access_stats WHERE kind=? AND app_id=0 AND date >= ? ORDER BY date ASC',
+        [$kind, $since],
+        'log'
+    );
+    return $rows ? $rows : [];
+}
+
+/**
+ * アクセス数上位の作品一覧を取得する
+ */
+function n3s_stats_top_apps($kind, $since, $limit = 10)
+{
+    $rows = db_get(
+        'SELECT app_id, SUM(count) AS total FROM access_stats
+          WHERE kind=? AND app_id > 0 AND date >= ?
+          GROUP BY app_id ORDER BY total DESC LIMIT ?',
+        [$kind, $since, $limit],
+        'log'
+    );
+    if (!$rows) { return []; }
+    // タイトルをメインDBから補完
+    foreach ($rows as &$row) {
+        $app = db_get1('SELECT title, author FROM apps WHERE app_id=?', [$row['app_id']]);
+        $row['title']  = $app ? $app['title']  : '(削除済み)';
+        $row['author'] = $app ? $app['author'] : '';
+    }
+    return $rows;
+}

--- a/app/action/widget_frame.inc.php
+++ b/app/action/widget_frame.inc.php
@@ -23,6 +23,16 @@ function n3s_web_widget_frame()
     $a['w_noname'] = in_array('w_noname', $tags);
     $a['api_token'] = isset($_GET['api_token']) ? $_GET['api_token'] : '';
 
+    // ウィジェット実行統計を記録 (Issue #217)
+    // run=1 かつ作品オーナー本人でない場合のみカウント
+    if ($a['run'] === 1 && !empty($a['app_id'])) {
+        $owner_id = intval(isset($a['user_id']) ? $a['user_id'] : 0);
+        $is_owner = ($owner_id > 0 && n3s_get_user_id() === $owner_id);
+        if (!$is_owner) {
+            n3s_record_access('widget', $a['app_id']);
+        }
+    }
+
     // nakotypeの例外(html/text/javascript)のときの処理
     // 注意: nakotype は必ずDBに保存された値($a['nakotype'])を使うこと。
     // 以前は $_GET['nakotype'] を信用していたため、任意の作品(非ログインでも

--- a/app/n3s_lib.inc.php
+++ b/app/n3s_lib.inc.php
@@ -45,6 +45,7 @@ function n3s_db_init()
     // 既存DB(init-users.sqlが実行済み)向けの軽量マイグレーション
     n3s_db_migrate_users();
     n3s_db_migrate_comments();
+    n3s_db_migrate_access_stats(); // アクセス統計テーブル (Issue #217)
 
     // v0.7未満で利用(過去のDB参照のため) #80
     /*
@@ -121,6 +122,53 @@ function n3s_db_migrate_comments()
       reason      TEXT DEFAULT '',
       ctime       INTEGER DEFAULT 0
     )", [], 'main');
+}
+
+// log DB に access_stats テーブルが無ければ作成する (Issue #217)
+function n3s_db_migrate_access_stats()
+{
+    db_exec(
+        'CREATE TABLE IF NOT EXISTS access_stats (
+            stat_id INTEGER PRIMARY KEY,
+            date    TEXT NOT NULL,
+            kind    TEXT NOT NULL,
+            app_id  INTEGER DEFAULT 0,
+            count   INTEGER DEFAULT 0,
+            UNIQUE(date, kind, app_id)
+        )',
+        [],
+        'log'
+    );
+}
+
+/**
+ * アクセス統計を日別にアップサートする (Issue #217)
+ *
+ * @param string $kind   'show' | 'widget' | 'api'
+ * @param int    $app_id 対象の app_id (0 = 全体)
+ */
+function n3s_record_access($kind, $app_id)
+{
+    $date = date('Y-m-d');
+    $app_id = intval($app_id);
+    // アプリ単位のカウントアップ
+    db_exec(
+        'INSERT INTO access_stats (date, kind, app_id, count)
+         VALUES (?, ?, ?, 1)
+         ON CONFLICT(date, kind, app_id) DO UPDATE SET count = count + 1',
+        [$date, $kind, $app_id],
+        'log'
+    );
+    // 全体合計 (app_id=0) のカウントアップ
+    if ($app_id !== 0) {
+        db_exec(
+            'INSERT INTO access_stats (date, kind, app_id, count)
+             VALUES (?, ?, 0, 1)
+             ON CONFLICT(date, kind, app_id) DO UPDATE SET count = count + 1',
+            [$date, $kind],
+            'log'
+        );
+    }
 }
 
 /**

--- a/app/n3s_lib.inc.php
+++ b/app/n3s_lib.inc.php
@@ -289,6 +289,14 @@ function n3s_parseURI()
         empty($_SERVER['HTTP_HOST']) ? 'localhost' : $_SERVER['HTTP_HOST'],
         $script_dir
     );
+    // dynamically determine app_root_url if it is default or empty, and sandbox_url is not set (same-origin)
+    $app_root_url = isset($n3s_config['app_root_url']) ? trim($n3s_config['app_root_url']) : '';
+    if ($app_root_url === '' || $app_root_url === 'http://localhost/repos/nako3storage/') {
+        $sandbox_url = isset($n3s_config['sandbox_url']) ? trim($n3s_config['sandbox_url']) : '';
+        if ($sandbox_url === '') {
+            $n3s_config['app_root_url'] = rtrim($n3s_config['baseurl'], '/') . '/';
+        }
+    }
 }
 
 function n3s_get_db($type = 'main')

--- a/app/sql/init-log.sql
+++ b/app/sql/init-log.sql
@@ -12,3 +12,13 @@ CREATE TABLE ip_check (
     memo TEXT DEFAULT '',
     ctime INTEGER
 );
+
+/* 2026/07 日別アクセス統計 (Issue #217) */
+CREATE TABLE IF NOT EXISTS access_stats (
+    stat_id INTEGER PRIMARY KEY,
+    date    TEXT NOT NULL,       /* 'YYYY-MM-DD' */
+    kind    TEXT NOT NULL,       /* 'show' | 'widget' | 'api' */
+    app_id  INTEGER DEFAULT 0,   /* 0 = 全体合計 */
+    count   INTEGER DEFAULT 0,
+    UNIQUE(date, kind, app_id)
+);

--- a/app/template/admin.html
+++ b/app/template/admin.html
@@ -2,6 +2,7 @@
 
 <div class="showblock">
     <h1>管理者専用ページ</h1>
+    <p><a href="index.php?action=stats" class="pure-button">📊 アクセス統計を見る</a></p>
     <h2>ログ</h2>
     <div>
         <ul>

--- a/app/template/stats.html
+++ b/app/template/stats.html
@@ -1,0 +1,101 @@
+{{ include parts_html_header.html }}
+
+<div class="showblock">
+  <h1>📊 アクセス統計 (直近{{$days}}日間)</h1>
+  <p>集計期間: {{$since}} 〜 本日</p>
+
+  <h2>サマリー</h2>
+  <table class="pure-table pure-table-bordered" style="width:100%;max-width:500px">
+    <thead>
+      <tr><th>種別</th><th>合計</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>👀 作品ページ閲覧 (show)</td><td>{{$total_show}}</td></tr>
+      <tr><td>▶️ ウィジェット実行 (widget)</td><td>{{$total_widget}}</td></tr>
+      <tr><td>🔌 API アクセス (api)</td><td>{{$total_api}}</td></tr>
+    </tbody>
+  </table>
+
+  <h2>日別推移</h2>
+  <div style="max-width:900px; margin-bottom:2em;">
+    <canvas id="stats-chart" height="80"></canvas>
+  </div>
+
+  <h2>閲覧数 上位作品 (show)</h2>
+  {{if $top_show}}
+  <table class="pure-table pure-table-bordered" style="width:100%;max-width:700px">
+    <thead>
+      <tr><th>#</th><th>作品</th><th>作者</th><th>閲覧数</th></tr>
+    </thead>
+    <tbody>
+    {{e: $n = 0; }}
+    {{for $top_show as $i=>$row}}
+    {{e: $n++; }}
+      <tr>
+        <td>{{$n}}</td>
+        <td><a href="index.php?action=show&page={{$row.app_id}}">{{$row.title}}</a></td>
+        <td>{{$row.author}}</td>
+        <td>{{$row.total}}</td>
+      </tr>
+    {{endfor}}
+    </tbody>
+  </table>
+  {{else}}
+  <p>データなし</p>
+  {{endif}}
+
+  <h2>実行数 上位作品 (widget)</h2>
+  {{if $top_widget}}
+  <table class="pure-table pure-table-bordered" style="width:100%;max-width:700px">
+    <thead>
+      <tr><th>#</th><th>作品</th><th>作者</th><th>実行数</th></tr>
+    </thead>
+    <tbody>
+    {{e: $n = 0; }}
+    {{for $top_widget as $i=>$row}}
+    {{e: $n++; }}
+      <tr>
+        <td>{{$n}}</td>
+        <td><a href="index.php?action=show&page={{$row.app_id}}">{{$row.title}}</a></td>
+        <td>{{$row.author}}</td>
+        <td>{{$row.total}}</td>
+      </tr>
+    {{endfor}}
+    </tbody>
+  </table>
+  {{else}}
+  <p>データなし</p>
+  {{endif}}
+
+  <p><a href="index.php?action=admin" class="pure-button">← ログページに戻る</a></p>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/chart.js@3.2.1/dist/chart.min.js"
+  integrity="sha256-uVEHWRIr846/vAdLJeybWxjPNStREzOlqLMXjW/Saeo=" crossorigin="anonymous"></script>
+<script>
+(function() {
+  var labels  = {{$date_labels | safe}};
+  var show    = {{$show_counts | safe}};
+  var widget  = {{$widget_counts | safe}};
+  var api     = {{$api_counts | safe}};
+  var ctx = document.getElementById('stats-chart').getContext('2d');
+  new Chart(ctx, {
+    type: 'line',
+    data: {
+      labels: labels,
+      datasets: [
+        { label: '閲覧 (show)',    data: show,   borderColor: '#4e8cff', backgroundColor: 'rgba(78,140,255,0.1)', fill: true, tension: 0.3 },
+        { label: '実行 (widget)', data: widget, borderColor: '#f0a500', backgroundColor: 'rgba(240,165,0,0.1)',  fill: true, tension: 0.3 },
+        { label: 'API',           data: api,    borderColor: '#38b56a', backgroundColor: 'rgba(56,181,106,0.1)', fill: true, tension: 0.3 }
+      ]
+    },
+    options: {
+      responsive: true,
+      plugins: { legend: { position: 'top' } },
+      scales: { y: { beginAtZero: true } }
+    }
+  });
+})();
+</script>
+
+{{ include parts_html_footer.html }}

--- a/app/template/widget.html
+++ b/app/template/widget.html
@@ -134,17 +134,44 @@
     <script>
       const editor = 'editor';
       const start_screen = document.getElementById('start_screen')
+      // run=0 のとき、「実行」ボタンが押されたら統計APIを呼ぶ (Issue #217)
+      const _n3s_run_mode = {{ $run }};
+      var _n3s_widget_counted = false; // 1セッション内での重複カウント防止
+      function _n3s_record_widget_run() {
+        if (_n3s_run_mode !== 0) { return; } // run=1 はサーバーサイドで計上済み
+        if (_n3s_widget_counted) { return; }
+        _n3s_widget_counted = true;
+        try {
+          fetch('api.php?action=rec_widget&page=' + app_id, {
+            method: 'GET',
+            credentials: 'include'
+          }).catch(function() {}); // エラーは無視（fire-and-forget）
+        } catch(e) {}
+      }
       function runNako3() {
         start_screen.style.display = 'none'
+        _n3s_record_widget_run()
         runButtonOnClick()
         setTimeout(() => {
           postFrameHeight()
         }, 100)
       }
       start_screen.onclick = runNako3
-      {{ if $run eq 1 }}
-      document.addEventListener("DOMContentLoaded", runNako3);
-      {{ endif }}
+      // nako3storage_show.js (defer) がrunButtonをセットした後にラップする
+      // defer スクリプトは DOMContentLoaded 発火前に実行されるため DOMContentLoaded で OK
+      document.addEventListener("DOMContentLoaded", function() {
+        // runButtonOnClick をラップして統計記録を挟む
+        if (typeof runButtonOnClick === 'function') {
+          var _origRunButtonOnClick = runButtonOnClick;
+          runButtonOnClick = function() {
+            _n3s_record_widget_run();
+            _origRunButtonOnClick.apply(this, arguments);
+          };
+        }
+        {{ if $run eq 1 }}
+        runNako3();
+        {{ endif }}
+      });
       // post fame height
       function postFrameHeight() {
         let scHeight = document.getElementsByTagName("html")[0].scrollHeight

--- a/tests/Feature/RecWidgetTest.php
+++ b/tests/Feature/RecWidgetTest.php
@@ -1,0 +1,157 @@
+<?php
+// tests/Feature/RecWidgetTest.php
+// n3s_api_rec_widget() の統合テスト (Issue #217 / P1 security fix)
+//
+// テスト対象:
+//  - 公開作品は count が記録される
+//  - 非公開 (is_private=1) は editkey 不問でカウントされない
+//  - 限定公開 (is_private=2) は editkey なしではカウントされない (P1 修正の回帰防止)
+//  - 限定公開は正しい editkey があればカウントされる
+//  - ログイン投稿オーナー本人の実行はカウントされない (テスト実行除外)
+//  - 匿名投稿 (user_id=0) はオーナー特定不可のため全件カウントする
+//  - app_id が不正 / 存在しないときはエラーなく空レスポンスを返す
+
+declare(strict_types=1);
+
+require_once N3S_TEST_ROOT . '/app/n3s_lib.inc.php';
+require_once N3S_TEST_ROOT . '/app/action/rec_widget.inc.php';
+
+// ------------------------------------------------
+// ヘルパー
+// ------------------------------------------------
+
+/** access_stats から当日の widget カウントを取得する */
+function _rw_widget_count(int $app_id): int
+{
+    $date = date('Y-m-d');
+    $row = db_get1(
+        'SELECT count FROM access_stats WHERE date=? AND kind=? AND app_id=?',
+        [$date, 'widget', $app_id],
+        'log'
+    );
+    return $row ? (int)$row['count'] : 0;
+}
+
+/** apps テーブルにテスト用の作品を挿入して app_id を返す */
+function _rw_insert_app($user_id, int $is_private, string $editkey = ''): int
+{
+    $user_id = intval($user_id); // n3s_add_user() は string を返す場合がある
+    return (int)db_insert(
+        'INSERT INTO apps (title, user_id, is_private, editkey, ctime) VALUES (?,?,?,?,?)',
+        ['テスト作品', $user_id, $is_private, $editkey, time()]
+    );
+}
+
+/** $_GET を設定して n3s_api_rec_widget() を呼び、JSON 文字列を返す */
+function _rw_call(int $app_id, string $editkey = ''): string
+{
+    $_GET['page'] = (string)$app_id;
+    if ($editkey !== '') {
+        $_GET['editkey'] = $editkey;
+    } else {
+        unset($_GET['editkey']);
+    }
+    return n3s_test_capture(fn () => n3s_api_rec_widget());
+}
+
+// ------------------------------------------------
+// テスト
+// ------------------------------------------------
+
+test('公開作品 (is_private=0) は editkey なしでカウントされる', function () {
+    $app_id = _rw_insert_app(0, 0);
+    _rw_call($app_id);
+    expect(_rw_widget_count($app_id))->toBe(1);
+});
+
+test('非公開作品 (is_private=1) は editkey を渡してもカウントされない', function () {
+    $owner_id = n3s_add_user('priv1@example.com', 'pass', '非公開オーナー');
+    $app_id = _rw_insert_app($owner_id, 1, 'secret');
+    _rw_call($app_id, 'secret');
+    expect(_rw_widget_count($app_id))->toBe(0);
+});
+
+test('限定公開 (is_private=2) を editkey なしで呼んでもカウントされない (P1 回帰防止)', function () {
+    $owner_id = n3s_add_user('limited1@example.com', 'pass', '限定公開オーナー');
+    $app_id = _rw_insert_app($owner_id, 2, 'sharekey');
+    _rw_call($app_id); // editkey なし
+    expect(_rw_widget_count($app_id))->toBe(0);
+});
+
+test('限定公開 (is_private=2) は正しい editkey があればカウントされる', function () {
+    $owner_id = n3s_add_user('limited2@example.com', 'pass', '限定公開オーナー2');
+    $app_id = _rw_insert_app($owner_id, 2, 'sharekey');
+    _rw_call($app_id, 'sharekey'); // 正しい editkey
+    expect(_rw_widget_count($app_id))->toBe(1);
+});
+
+test('限定公開 (is_private=2) は間違った editkey ではカウントされない', function () {
+    $owner_id = n3s_add_user('limited3@example.com', 'pass', '限定公開オーナー3');
+    $app_id = _rw_insert_app($owner_id, 2, 'sharekey');
+    _rw_call($app_id, 'wrongkey');
+    expect(_rw_widget_count($app_id))->toBe(0);
+});
+
+test('ログイン投稿のオーナー本人が実行してもカウントされない (テスト実行除外)', function () {
+    $owner_id = n3s_add_user('owner1@example.com', 'pass', 'オーナー');
+    $app_id = _rw_insert_app($owner_id, 0);
+
+    // オーナー本人でログイン
+    n3s_web_login_execute('owner1@example.com', 'pass');
+    expect(n3s_get_user_id())->toBe((int)$owner_id);
+
+    _rw_call($app_id);
+    expect(_rw_widget_count($app_id))->toBe(0);
+});
+
+test('ログイン投稿の作品でも他人の実行はカウントされる', function () {
+    $owner_id = n3s_add_user('owner2@example.com', 'pass', 'オーナー2');
+    $other_id  = n3s_add_user('other@example.com', 'pass', '他ユーザー');
+    $app_id = _rw_insert_app($owner_id, 0);
+
+    // 他人でログイン
+    n3s_web_login_execute('other@example.com', 'pass');
+    _rw_call($app_id);
+    expect(_rw_widget_count($app_id))->toBe(1);
+});
+
+test('ログアウト状態でのアクセスはカウントされる（匿名ユーザー）', function () {
+    $owner_id = n3s_add_user('owner3@example.com', 'pass', 'オーナー3');
+    $app_id = _rw_insert_app($owner_id, 0);
+    // $_SESSION を空にしてログアウト状態を再現（beforeEach でリセット済みだが念のため）
+    $_SESSION = [];
+    _rw_call($app_id);
+    expect(_rw_widget_count($app_id))->toBe(1);
+});
+
+test('匿名投稿 (user_id=0) の作品はオーナー特定不可のため常にカウントされる', function () {
+    $app_id = _rw_insert_app(0, 0); // user_id=0 = 匿名投稿
+    _rw_call($app_id);
+    expect(_rw_widget_count($app_id))->toBe(1);
+});
+
+test('app_id が 0 以下のときはエラーなく false レスポンスを返す', function () {
+    $_GET['page'] = '0';
+    $out = n3s_test_capture(fn () => n3s_api_rec_widget());
+    $json = json_decode($out, true);
+    expect($json['result'])->toBeFalse();
+});
+
+test('存在しない app_id を渡してもエラーなく true レスポンスを返す（情報漏洩防止）', function () {
+    $out = _rw_call(99999);
+    $json = json_decode($out, true);
+    expect($json['result'])->toBeTrue();
+    // カウントは記録されない
+    expect(_rw_widget_count(99999))->toBe(0);
+});
+
+test('公開作品を複数回呼んでも日別集計として累積される（二重カウントの意図的な動作確認）', function () {
+    // 同じセッション内で「実行」ボタンを複数回押した場合のサーバー側は
+    // リクエストごとにカウントする（JS 側で _n3s_widget_counted フラグにより
+    // 1回のページロードにつき 1 回のみ fetch することを前提とする）
+    $app_id = _rw_insert_app(0, 0);
+    _rw_call($app_id);
+    _rw_call($app_id);
+    _rw_call($app_id);
+    expect(_rw_widget_count($app_id))->toBe(3);
+});

--- a/tests/Unit/AccessStatsTest.php
+++ b/tests/Unit/AccessStatsTest.php
@@ -1,0 +1,92 @@
+<?php
+// tests/Unit/AccessStatsTest.php
+// n3s_record_access() と n3s_db_migrate_access_stats() の単体テスト (Issue #217)
+//
+// テスト対象:
+//  - 日別アップサート（同日同種別は count が加算される）
+//  - 異なる日・異なる種別は独立したレコードになる
+//  - app_id=0 のグローバル合計が自動で加算される
+//  - n3s_db_migrate_access_stats() が既存 DB にテーブルを追加できる
+
+declare(strict_types=1);
+
+require_once N3S_TEST_ROOT . '/app/n3s_lib.inc.php';
+
+// ------------------------------------------------
+// ヘルパー
+// ------------------------------------------------
+
+/** access_stats から 1 行取得する */
+function _stats_get(string $date, string $kind, int $app_id): ?array
+{
+    $row = db_get1(
+        'SELECT * FROM access_stats WHERE date=? AND kind=? AND app_id=?',
+        [$date, $kind, $app_id],
+        'log'
+    );
+    return $row ?: null;
+}
+
+/** access_stats の count を取得する（行がなければ 0） */
+function _stats_count(string $date, string $kind, int $app_id): int
+{
+    $row = _stats_get($date, $kind, $app_id);
+    return $row ? (int)$row['count'] : 0;
+}
+
+// ------------------------------------------------
+// テスト
+// ------------------------------------------------
+
+test('n3s_record_access() は同日同種別 app_id のカウントを 1 増やす', function () {
+    $date = date('Y-m-d');
+    n3s_record_access('show', 10);
+    expect(_stats_count($date, 'show', 10))->toBe(1);
+});
+
+test('n3s_record_access() を複数回呼ぶと count が累積される', function () {
+    $date = date('Y-m-d');
+    n3s_record_access('show', 20);
+    n3s_record_access('show', 20);
+    n3s_record_access('show', 20);
+    expect(_stats_count($date, 'show', 20))->toBe(3);
+});
+
+test('n3s_record_access() は app_id=0 のグローバル合計も同時にカウントアップする', function () {
+    $date = date('Y-m-d');
+    n3s_record_access('show', 30);
+    n3s_record_access('show', 30);
+    // アプリ単位
+    expect(_stats_count($date, 'show', 30))->toBe(2);
+    // 全体合計
+    expect(_stats_count($date, 'show', 0))->toBeGreaterThanOrEqual(2);
+});
+
+test('n3s_record_access() を app_id=0 で呼んでも全体合計を二重計上しない', function () {
+    $date = date('Y-m-d');
+    // app_id=0 を直接指定した場合は全体合計への自動追加はスキップされる
+    n3s_record_access('widget', 0);
+    n3s_record_access('widget', 0);
+    expect(_stats_count($date, 'widget', 0))->toBe(2);
+});
+
+test('種別 (kind) が異なれば独立したレコードになる', function () {
+    $date = date('Y-m-d');
+    n3s_record_access('show',   40);
+    n3s_record_access('widget', 40);
+    n3s_record_access('api',    40);
+    expect(_stats_count($date, 'show',   40))->toBe(1);
+    expect(_stats_count($date, 'widget', 40))->toBe(1);
+    expect(_stats_count($date, 'api',    40))->toBe(1);
+});
+
+test('n3s_db_migrate_access_stats() は既存 DB に access_stats テーブルを作成する', function () {
+    // bootstrap で database_set() 済みの log DB を対象に再度マイグレーションを呼んでも
+    // CREATE TABLE IF NOT EXISTS なので冪等であることも確認する
+    n3s_db_migrate_access_stats();
+    n3s_db_migrate_access_stats(); // 2回目もエラーにならない
+
+    n3s_record_access('api', 1);
+    $date = date('Y-m-d');
+    expect(_stats_count($date, 'api', 1))->toBe(1);
+});


### PR DESCRIPTION
## 概要

Issue #217 の実装です。アクセス数・実行回数を日別に集計し、管理者が統計を確認できるようにします。

## 計測ポイント

| 種別 | トリガー | 実装場所 |
|---|---|---|
| show（閲覧） | 作品ページを開いたとき | `n3s_web_show()` (サーバーサイド) |
| api（API アクセス） | `api.php?action=show` にアクセスしたとき | `n3s_api_show()` (サーバーサイド) |
| widget/run=1（即時実行） | ウィジェットが `run=1` で読み込まれたとき | `n3s_web_widget_frame()` (サーバーサイド) |
| widget/run=0（手動実行） | ウィジェットの「▶ 実行」ボタンを押したとき | `widget.html` → `fetch api.php?action=rec_widget` (クライアントサイド) |

## オーナー除外ルール

ウィジェット実行（widget）のカウントのみ、**ログイン中のユーザーが作品投稿者本人の場合はスキップ**します（テスト実行を除外）。閲覧・API アクセスはオーナーでもカウントします。

## DB 変更

`data/n3s_log.sqlite` に `access_stats` テーブルを追加します（既存 DB には起動時に自動マイグレーション）。

```sql
CREATE TABLE IF NOT EXISTS access_stats (
    stat_id INTEGER PRIMARY KEY,
    date    TEXT NOT NULL,       -- 'YYYY-MM-DD'
    kind    TEXT NOT NULL,       -- 'show' | 'widget' | 'api'
    app_id  INTEGER DEFAULT 0,   -- 0 = 全体合計
    count   INTEGER DEFAULT 0,
    UNIQUE(date, kind, app_id)
);
```

## 追加・変更ファイル

- `app/sql/init-log.sql` — `access_stats` テーブル定義を追加
- `app/n3s_lib.inc.php` — `n3s_db_migrate_access_stats()`、`n3s_record_access()` を追加
- `app/action/show.inc.php` — 閲覧・API 統計の記録を追加
- `app/action/widget_frame.inc.php` — ウィジェット実行統計の記録を追加（オーナー除外）
- `app/action/rec_widget.inc.php` — run=0 用の統計記録 API エンドポイント（新規）
- `app/action/stats.inc.php` — 管理者向け統計表示ページ（新規）
- `app/template/stats.html` — 統計ページテンプレート（新規）
- `app/template/admin.html` — 「📊 アクセス統計を見る」リンクを追加
- `app/template/widget.html` — run=0 時の実行ボタン押下を fetch で記録

## 確認方法

```sh
# ローカルサーバー起動
php -S localhost:8000

# 作品ページを閲覧
open http://localhost:8000/index.php?action=show&page=1

# 統計ページ（管理者ログイン後）
open http://localhost:8000/index.php?action=stats
```

## テスト

```
Tests: 199 passed (517 assertions)
```